### PR TITLE
[codex] Add GameNow pages

### DIFF
--- a/gamenow/index.html
+++ b/gamenow/index.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GameNow - Aprenda inglês jogando</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', sans-serif;
+      line-height: 1.6;
+      color: #333;
+      background: #f8f9fa;
+    }
+    header {
+      background: linear-gradient(135deg, #ff9500 0%, #ff7200 100%);
+      color: white;
+      padding: 40px 20px;
+      text-align: center;
+    }
+    header h1 {
+      font-size: 48px;
+      margin-bottom: 10px;
+    }
+    header p {
+      font-size: 20px;
+      opacity: 0.95;
+    }
+    .container {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 40px 20px;
+    }
+    .feature {
+      background: white;
+      border-radius: 12px;
+      padding: 30px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+    .feature h2 {
+      color: #ff9500;
+      margin-bottom: 15px;
+      font-size: 24px;
+    }
+    .feature ul {
+      margin-left: 20px;
+      margin-top: 10px;
+    }
+    .feature li {
+      margin-bottom: 8px;
+    }
+    .cta {
+      text-align: center;
+      margin: 40px 0;
+    }
+    .btn {
+      display: inline-block;
+      background: #ff9500;
+      color: white;
+      padding: 14px 32px;
+      border-radius: 8px;
+      text-decoration: none;
+      font-weight: 600;
+      margin: 10px;
+      transition: background 0.3s;
+    }
+    .btn:hover {
+      background: #ff7200;
+    }
+    footer {
+      background: #333;
+      color: white;
+      text-align: center;
+      padding: 30px 20px;
+      margin-top: 60px;
+    }
+    footer a {
+      color: #ff9500;
+      text-decoration: none;
+    }
+    footer a:hover {
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>🎮 GameNow</h1>
+    <p>Aprenda inglês jogando blocos</p>
+  </header>
+
+  <div class="container">
+    <div class="feature">
+      <h2>O que é GameNow?</h2>
+      <p>Um jogo de blocos viciante + quizzes de vocabulário em inglês integrados. Cada linha que você limpa no tabuleiro dispara uma pergunta. Aprenda sem perceber.</p>
+    </div>
+
+    <div class="feature">
+      <h2>Como funciona</h2>
+      <ul>
+        <li>Monte peças no tabuleiro e complete linhas</li>
+        <li>Cada linha limpa traz um quiz de inglês</li>
+        <li>Escolha a tradução, complete uma frase, ouça uma palavra ou digite</li>
+        <li>Repetição espaçada (SM-2) traz de volta as palavras que você não sabe</li>
+      </ul>
+    </div>
+
+    <div class="feature">
+      <h2>Recursos</h2>
+      <ul>
+        <li>✅ Sem anúncios</li>
+        <li>✅ 100% offline</li>
+        <li>✅ Seus dados no seu dispositivo (sem sincronização)</li>
+        <li>✅ Múltiplos modos de quiz (tradução, cloze, colocações, digitação, áudio)</li>
+        <li>✅ Palavras de A1 até C1 (padrão CEFR)</li>
+        <li>✅ Pacotes gratuitos e pagos</li>
+      </ul>
+    </div>
+
+    <div class="feature">
+      <h2>Disponível em</h2>
+      <p>
+        <a href="https://apps.apple.com" class="btn">App Store</a>
+      </p>
+    </div>
+
+    <div class="cta">
+      <h3>Dúvidas?</h3>
+      <p>
+        <a href="/support.html" class="btn">Suporte</a>
+        <a href="/privacy-policy.html" class="btn">Privacidade</a>
+      </p>
+    </div>
+  </div>
+
+  <footer>
+    <p>&copy; 2026 Pablo Custodio Carneiro. Todos os direitos reservados.</p>
+    <p style="margin-top: 15px; font-size: 14px;">
+      <a href="/privacy-policy.html">Política de Privacidade</a> •
+      <a href="/terms-of-service.html">Termos de Serviço</a> •
+      <a href="/support.html">Suporte</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/gamenow/privacy-policy.html
+++ b/gamenow/privacy-policy.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Política de Privacidade - GameNow</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', sans-serif;
+      line-height: 1.8;
+      color: #333;
+      background: #f8f9fa;
+    }
+    header {
+      background: linear-gradient(135deg, #ff9500 0%, #ff7200 100%);
+      color: white;
+      padding: 40px 20px;
+      text-align: center;
+    }
+    header h1 {
+      font-size: 40px;
+      margin-bottom: 10px;
+    }
+    .container {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 40px 20px;
+      background: white;
+    }
+    h2 {
+      color: #ff9500;
+      margin-top: 40px;
+      margin-bottom: 15px;
+      font-size: 24px;
+      border-bottom: 2px solid #ff9500;
+      padding-bottom: 10px;
+    }
+    h2:first-child {
+      margin-top: 0;
+    }
+    h3 {
+      color: #333;
+      margin-top: 25px;
+      margin-bottom: 10px;
+      font-size: 18px;
+    }
+    p {
+      margin-bottom: 15px;
+    }
+    ul {
+      margin-left: 20px;
+      margin-bottom: 15px;
+    }
+    li {
+      margin-bottom: 10px;
+    }
+    strong {
+      color: #000;
+    }
+    .highlight {
+      background: #fff3cd;
+      border-left: 4px solid #ff9500;
+      padding: 15px;
+      border-radius: 4px;
+      margin: 20px 0;
+    }
+    .last-update {
+      color: #666;
+      font-size: 14px;
+      margin-bottom: 30px;
+    }
+    a {
+      color: #ff9500;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    footer {
+      background: #333;
+      color: white;
+      text-align: center;
+      padding: 30px 20px;
+      margin-top: 60px;
+    }
+    footer a {
+      color: #ff9500;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Política de Privacidade</h1>
+    <p>GameNow</p>
+  </header>
+
+  <div class="container">
+    <p class="last-update"><strong>Última atualização:</strong> 2 de maio de 2026</p>
+
+    <h2>1. Introdução</h2>
+    <p>GameNow é um aplicativo educacional para aprender vocabulário em inglês enquanto joga. Esta política descreve como coletamos, usamos e protegemos suas informações.</p>
+
+    <div class="highlight">
+      <strong>Resumo rápido:</strong> GameNow não coleta dados pessoais. Seu progresso fica no seu dispositivo. Sem servidores remotos. Sem sincronização. Sem contas obrigatórias.
+    </div>
+
+    <h2>2. Dados que coletamos (ou não coletamos)</h2>
+
+    <h3>Dados NÃO coletados</h3>
+    <p>GameNow <strong>nunca solicita ou armazena</strong>:</p>
+    <ul>
+      <li>Email, nome ou identificador pessoal</li>
+      <li>Localização geográfica</li>
+      <li>Contatos ou dados de saúde</li>
+      <li>Fotos ou documentos</li>
+      <li>Histórico de navegação ou redes sociais</li>
+    </ul>
+
+    <h3>Dados armazenados LOCALMENTE no seu dispositivo</h3>
+    <p>Seu progresso é salvo apenas no seu iPhone/iPad usando <strong>UserDefaults</strong> (armazenamento local nativo do iOS). Dados incluem:</p>
+    <ul>
+      <li>Palavras que você estudou</li>
+      <li>Nível de maestria de cada palavra (novo/aprendendo/revisando/dominado)</li>
+      <li>Estatísticas de quiz: acertos, erros, tempos de resposta</li>
+      <li>Nível CEFR selecionado (A1-C2)</li>
+      <li>Preferências: tema (claro/escuro), modo de quiz padrão, volume de som</li>
+      <li>Histórico de limpezas (lines cleared) para pontuação</li>
+    </ul>
+    <p><strong>Nenhum desses dados é enviado para um servidor remoto.</strong> Você é o único dono dos seus dados.</p>
+
+    <h3>Você pode apagar seus dados</h3>
+    <p>Desinstale GameNow e seus dados locais são deletados automaticamente. Não há backup na nuvem para deletar separadamente.</p>
+
+    <h2>3. Compras na Apple (StoreKit 2)</h2>
+    <p>Pacotes de vocabulário adicionais são comprados via App Store usando <strong>StoreKit 2</strong> (plataforma de compra nativa da Apple).</p>
+
+    <h3>O que GameNow não vê</h3>
+    <ul>
+      <li>Número do seu cartão de crédito</li>
+      <li>Dados de billing (endereço, telefone)</li>
+      <li>Seu endereço de email (a menos que você compartilhe voluntariamente)</li>
+      <li>Histórico de compras anteriores</li>
+    </ul>
+
+    <h3>O que acontece com compras</h3>
+    <p><strong>A Apple gerencia tudo.</strong> GameNow apenas recebe uma confirmação de que você comprou um pacote. O aplicativo então desbloqueia acesso àquele pacote no seu dispositivo.</p>
+
+    <p>Para informações sobre como a Apple processa pagamentos, veja:</p>
+    <ul>
+      <li><a href="https://www.apple.com/privacy/">Política de Privacidade da Apple</a></li>
+      <li><a href="https://www.apple.com/legal/internet-services/itunes/">Termos do iTunes/App Store</a></li>
+    </ul>
+
+    <h2>4. Analytics e Telemetria (Opcional)</h2>
+
+    <h3>Você controla isso</h3>
+    <p>Em <strong>Configurações → Privacidade</strong>, você pode:</p>
+    <ul>
+      <li>✅ Ativar analytics: GameNow coleta eventos anônimos de gameplay</li>
+      <li>❌ Desativar analytics: nenhum dado é enviado (padrão)</li>
+    </ul>
+
+    <h3>Se ativado, o que é coletado</h3>
+    <p>Eventos anônimos (sem identificar você):</p>
+    <ul>
+      <li>Quantidade de quizzes respondidos</li>
+      <li>Taxa de acertos/erros geral</li>
+      <li>Qual modo de quiz você mais usa (múltipla escolha vs. cloze vs. digitação)</li>
+      <li>Se você tenta recursos como pronúncia ou listening</li>
+      <li>Tempo médio de gameplay por sessão</li>
+    </ul>
+
+    <p><strong>O que NÃO é coletado mesmo com analytics ativado:</strong></p>
+    <ul>
+      <li>Qual palavra específica você estudou (apenas contagens agregadas)</li>
+      <li>Seus acertos/erros individuais</li>
+      <li>Seu dispositivo, IP ou localização</li>
+      <li>Qualquer informação que identifique você</li>
+    </ul>
+
+    <h3>Onde os dados vão</h3>
+    <p>Se analytics está ativado, eventos são enviados para <strong>TelemetryDeck</strong> — um serviço de analytics europeu que respeita GDPR e não vende dados. Veja a <a href="https://telemetrydeck.com/privacy/">política de privacidade do TelemetryDeck</a>.</p>
+
+    <h2>5. Cookies e Rastreamento</h2>
+    <p>GameNow <strong>não usa cookies, web beacons ou pixel tracking.</strong> É um app nativo, não um navegador.</p>
+
+    <h2>6. Compartilhamento de dados com terceiros</h2>
+    <p>GameNow <strong>nunca vende, aluga ou compartilha seus dados</strong> com terceiros para marketing, publicidade ou qualquer outro propósito.</p>
+
+    <p>Exceções (você sempre controla):</p>
+    <ul>
+      <li><strong>Apple:</strong> Recebe notificação de compra (necessária para liberar pacotes)</li>
+      <li><strong>TelemetryDeck:</strong> Apenas se você ativar analytics (opcional)</li>
+    </ul>
+
+    <h2>7. Segurança</h2>
+    <p>Seu progresso é armazenado no device encryption nativo do iOS. A Apple gerencia toda a segurança de hardware e SO.</p>
+
+    <p>GameNow não usa senhas, autenticação de dois fatores ou login — porque não há contas remotas. Não há "conta hackeável".</p>
+
+    <h2>8. Conformidade com leis</h2>
+
+    <h3>LGPD (Lei Geral de Proteção de Dados — Brasil)</h3>
+    <p>GameNow cumpre LGPD:</p>
+    <ul>
+      <li>✅ Transparência: esta política deixa claro o que é coletado</li>
+      <li>✅ Consentimento: você opta por analytics em Configurações</li>
+      <li>✅ Direito de deletar: desinstale e seus dados locais somem</li>
+      <li>✅ Direito de acesso: seus dados estão no seu dispositivo (acesse via Settings → Privacy)</li>
+    </ul>
+
+    <h3>GDPR (Europa)</h3>
+    <p>GameNow cumpre GDPR para usuários europeus (se aplicável):</p>
+    <ul>
+      <li>Minimização de dados: só coleta o necessário</li>
+      <li>Consentimento afirmativo: opt-in para analytics</li>
+      <li>Direito ao esquecimento: deletar o app = deletar dados</li>
+    </ul>
+
+    <h3>COPPA (EUA — proteção de crianças)</h3>
+    <p>Se menores de 13 anos usarem GameNow:</p>
+    <ul>
+      <li>Nenhum dado pessoal é coletado (sem email, nome, etc.)</li>
+      <li>Nenhum rastreamento de publicidade</li>
+      <li>Compras no app requerem aprovação do responsável (controlado pela Apple via Family Sharing)</li>
+    </ul>
+
+    <h2>9. Retenção de dados</h2>
+    <p><strong>Dados locais:</strong> Mantidos enquanto o app estiver instalado. Deletados ao desinstalar.</p>
+
+    <p><strong>Dados de compra:</strong> Apple mantém histórico de compras pelo tempo que sua conta estiver ativa (padrão Apple).</p>
+
+    <p><strong>Analytics (se ativado):</strong> TelemetryDeck mantém dados agregados por 90 dias por padrão.</p>
+
+    <h2>10. Atualizações desta política</h2>
+    <p>GameNow pode atualizar esta política a qualquer momento. A data de última atualização está no topo. Se fizer mudanças significativas, tentarei notificar (via app ou email se fornecido).</p>
+
+    <h2>11. Contato</h2>
+    <p>Dúvidas sobre privacidade?</p>
+    <p><strong>Email:</strong> <a href="mailto:apple@pablocustodio.com.br">apple@pablocustodio.com.br</a></p>
+
+    <p>Respondo em português. Tempo médio de resposta: 24-48 horas.</p>
+
+    <h2>12. Resumo em uma frase</h2>
+    <p><strong>GameNow não coleta seus dados pessoais. Seu progresso fica no seu celular. Pronto.</strong></p>
+  </div>
+
+  <footer>
+    <p>&copy; 2026 Pablo Custodio Carneiro. Todos os direitos reservados.</p>
+    <p style="margin-top: 15px; font-size: 14px;">
+      <a href="/index.html">Início</a> •
+      <a href="/support.html">Suporte</a> •
+      <a href="/terms-of-service.html">Termos</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/gamenow/support.html
+++ b/gamenow/support.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Suporte - GameNow</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', sans-serif;
+      line-height: 1.6;
+      color: #333;
+      background: #f8f9fa;
+    }
+    header {
+      background: linear-gradient(135deg, #ff9500 0%, #ff7200 100%);
+      color: white;
+      padding: 40px 20px;
+      text-align: center;
+    }
+    header h1 {
+      font-size: 40px;
+      margin-bottom: 10px;
+    }
+    .container {
+      max-width: 700px;
+      margin: 0 auto;
+      padding: 40px 20px;
+    }
+    section {
+      background: white;
+      border-radius: 12px;
+      padding: 30px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+    section h2 {
+      color: #ff9500;
+      margin-bottom: 15px;
+      font-size: 24px;
+      border-bottom: 2px solid #ff9500;
+      padding-bottom: 10px;
+    }
+    section h3 {
+      color: #333;
+      margin-top: 20px;
+      margin-bottom: 10px;
+      font-size: 18px;
+    }
+    section h3:first-child {
+      margin-top: 0;
+    }
+    section p {
+      margin-bottom: 15px;
+    }
+    section ul {
+      margin-left: 20px;
+      margin-bottom: 15px;
+    }
+    section li {
+      margin-bottom: 8px;
+    }
+    .contact-box {
+      background: #f0f0f0;
+      border-left: 4px solid #ff9500;
+      padding: 20px;
+      border-radius: 8px;
+      margin: 20px 0;
+    }
+    .contact-box strong {
+      color: #ff9500;
+    }
+    a {
+      color: #ff9500;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    footer {
+      background: #333;
+      color: white;
+      text-align: center;
+      padding: 30px 20px;
+      margin-top: 60px;
+    }
+    footer a {
+      color: #ff9500;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Suporte GameNow</h1>
+  </header>
+
+  <div class="container">
+    <section>
+      <h2>Entre em contato</h2>
+      <div class="contact-box">
+        <p><strong>Email:</strong> <a href="mailto:apple@pablocustodio.com.br">apple@pablocustodio.com.br</a></p>
+        <p>Respondo em português. Tempo médio de resposta: 24-48 horas.</p>
+      </div>
+    </section>
+
+    <section>
+      <h2>Perguntas frequentes</h2>
+
+      <h3>Como funciona a repetição espaçada?</h3>
+      <p>GameNow usa o algoritmo SM-2 (SuperMemo-2) para trazer de volta as palavras que você ainda não domina. Palavras que você acerta com frequência voltam mais devagar. Palavras difíceis voltam logo, para reforçar a memória.</p>
+
+      <h3>Como mudo meu nível CEFR?</h3>
+      <p>Vá em Configurações (⚙️) → Nível CEFR e selecione outro nível. O app prioriza palavras do seu nível e um nível acima (estratégia i+1 de Krashen).</p>
+
+      <h3>Meus dados são sincronizados com a nuvem?</h3>
+      <p>Não. GameNow é 100% offline e local. Seu progresso (palavras estudadas, quizzes respondidos, estatísticas) fica armazenado apenas no seu dispositivo usando UserDefaults do iOS. Nenhum dado é enviado para servidores remotos.</p>
+
+      <h3>Como apago meus dados?</h3>
+      <p>Desinstale o app. Seus dados locais serão deletados automaticamente. Não há conta de usuário na nuvem para limpar.</p>
+
+      <h3>Qual é a diferença entre os pacotes gratuitos e pagos?</h3>
+      <p>O pacote gratuito (free-core) tem 50 palavras essenciais de negócios e cotidiano. Pacotes pagos adicionais incluem temas como viagem, business avançado, phrasal verbs, etc. Você pode estudar com o pacote gratuito indefinidamente.</p>
+
+      <h3>Como reporto um bug?</h3>
+      <p>Envie um email para <a href="mailto:apple@pablocustodio.com.br">apple@pablocustodio.com.br</a> com:</p>
+      <ul>
+        <li>Descrição clara do problema (o que aconteceu?)</li>
+        <li>Modelo do dispositivo e versão do iOS (Configurações → Geral → Sobre)</li>
+        <li>Versão do GameNow (Configurações → Sobre → Versão)</li>
+        <li>Passos para reproduzir o problema</li>
+      </ul>
+
+      <h3>Posso sugerir uma feature?</h3>
+      <p>Claro! Envie suas ideias por email. Leio todas as sugestões e considero para versões futuras.</p>
+
+      <h3>O app tem publicidade?</h3>
+      <p>Não. GameNow não tem anúncios e nunca terá. Usa um modelo de compra única por pacote (freemium) e doação opcional.</p>
+
+      <h3>O app funciona offline?</h3>
+      <p>Sim, 100%. Não precisa de internet para jogar ou estudar. Seu progresso é salvo localmente.</p>
+
+      <h3>Há suporte para outros idiomas?</h3>
+      <p>Atualmente, GameNow é apenas para aprender inglês. Mas inglês é o idioma mais falado do mundo, então é um bom começo! :)</p>
+
+      <h3>Como funciona a compra de pacotes?</h3>
+      <p>Pacotes adicionais são comprados via App Store (StoreKit 2). Após a compra, você tem acesso permanente a todas as palavras daquele pacote. Não há assinatura obrigatória — é uma compra única.</p>
+    </section>
+
+    <section>
+      <h2>Problemas comuns</h2>
+
+      <h3>O app não aparece no meu perfil do Family Sharing</h3>
+      <p>Se você comprou o app com uma conta diferente, ele não sincroniza automaticamente com outras contas. Você pode restaurar a compra: Configurações → [Seu nome] → iTunes e App Stores → restaurar compras.</p>
+
+      <h3>O quiz de pronúncia não funciona</h3>
+      <p>Verifique se:</p>
+      <ul>
+        <li>O microfone está habilitado em Configurações → GameNow → Microfone</li>
+        <li>Seu dispositivo tem microfone funcionando (iPhone/iPad)</li>
+        <li>Tente reiniciar o app</li>
+      </ul>
+
+      <h3>Não consigo restaurar minha compra</h3>
+      <p>Restaurar compras funciona apenas com a conta Apple ID que fez a compra original. Se comprou com outra conta, faça login com aquela conta (Configurações → [Seu nome] → iTunes e App Stores).</p>
+    </section>
+
+    <section>
+      <h2>Feedback</h2>
+      <p>Adoraria ouvir sua opinião! Se o app te ajudou a aprender inglês, considere deixar uma avaliação na App Store — isso significa muito para um desenvolvedor indie. 🙏</p>
+      <p>Para sugestões de features ou relatos de bugs, escreva para <a href="mailto:apple@pablocustodio.com.br">apple@pablocustodio.com.br</a>.</p>
+    </section>
+  </div>
+
+  <footer>
+    <p>&copy; 2026 Pablo Custodio Carneiro. Todos os direitos reservados.</p>
+    <p style="margin-top: 15px; font-size: 14px;">
+      <a href="/index.html">Início</a> •
+      <a href="/privacy-policy.html">Privacidade</a> •
+      <a href="/terms-of-service.html">Termos</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/gamenow/terms-of-service.html
+++ b/gamenow/terms-of-service.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Termos de Serviço - GameNow</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', sans-serif;
+      line-height: 1.8;
+      color: #333;
+      background: #f8f9fa;
+    }
+    header {
+      background: linear-gradient(135deg, #ff9500 0%, #ff7200 100%);
+      color: white;
+      padding: 40px 20px;
+      text-align: center;
+    }
+    header h1 {
+      font-size: 40px;
+      margin-bottom: 10px;
+    }
+    .container {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 40px 20px;
+      background: white;
+    }
+    h2 {
+      color: #ff9500;
+      margin-top: 40px;
+      margin-bottom: 15px;
+      font-size: 24px;
+      border-bottom: 2px solid #ff9500;
+      padding-bottom: 10px;
+    }
+    h2:first-child {
+      margin-top: 0;
+    }
+    h3 {
+      color: #333;
+      margin-top: 25px;
+      margin-bottom: 10px;
+      font-size: 18px;
+    }
+    p {
+      margin-bottom: 15px;
+    }
+    ul {
+      margin-left: 20px;
+      margin-bottom: 15px;
+    }
+    li {
+      margin-bottom: 10px;
+    }
+    strong {
+      color: #000;
+    }
+    .last-update {
+      color: #666;
+      font-size: 14px;
+      margin-bottom: 30px;
+    }
+    a {
+      color: #ff9500;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    footer {
+      background: #333;
+      color: white;
+      text-align: center;
+      padding: 30px 20px;
+      margin-top: 60px;
+    }
+    footer a {
+      color: #ff9500;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Termos de Serviço</h1>
+    <p>GameNow</p>
+  </header>
+
+  <div class="container">
+    <p class="last-update"><strong>Última atualização:</strong> 2 de maio de 2026</p>
+
+    <h2>1. Aceição dos termos</h2>
+    <p>Ao usar GameNow, você concorda com estes termos. Se não concorda, não use o aplicativo.</p>
+
+    <h2>2. Licença de uso</h2>
+    <p>GameNow lhe concede uma licença limitada, não exclusiva e revogável para usar o aplicativo em seu dispositivo pessoal para fins educacionais privados.</p>
+
+    <p><strong>Você não pode:</strong></p>
+    <ul>
+      <li>Copiar, modificar ou criar trabalhos derivados do app</li>
+      <li>Reverse engineer ou tentar descompilar o código</li>
+      <li>Usar o app para fins comerciais sem autorização</li>
+      <li>Distribuir, vender ou alugar o app</li>
+      <li>Compartilhar sua conta (se houver) com terceiros</li>
+    </ul>
+
+    <h2>3. Propriedade intelectual</h2>
+    <p>GameNow, seu código, design, conteúdo (palavras, frases de exemplo, collocations) e marca registrada são propriedade de Pablo Custodio Carneiro. Você não possui esses direitos apenas por usar o app.</p>
+
+    <p>Exceções:</p>
+    <ul>
+      <li><strong>Vocabulário público:</strong> Palavras em inglês em si não são propriedade. Você pode aprender e usar "deadline", "feedback", etc. livremente.</li>
+      <li><strong>Feedback:</strong> Comentários que você enviar por email podem ser usados para melhorar o app.</li>
+    </ul>
+
+    <h2>4. Conteúdo educacional</h2>
+
+    <h3>Acurácia</h3>
+    <p>GameNow tenta fornecer vocabulário correto e frases gramaticais em inglês. Mas <strong>sem garantia de perfeição</strong>. Se encontrar um erro, reporte por email.</p>
+
+    <h3>Uso responsável</h3>
+    <p>GameNow é um <strong>suplemento educacional</strong>, não substituto de um curso formal de inglês ou teste de proficiência. Não garantimos fluência ou resultado de exames (TOEFL, IELTS, etc.) apenas por usar o app.</p>
+
+    <h2>5. Compras na App Store</h2>
+
+    <h3>Reembolsos</h3>
+    <p>Reembolsos são gerenciados **pela Apple, não por GameNow**. Para solicitar reembolso:</p>
+    <ol>
+      <li>Abra a App Store no seu iPhone</li>
+      <li>Vá em Configurações (seu perfil) → Compras</li>
+      <li>Encontre GameNow</li>
+      <li>Toque em "Reportar um problema"</li>
+      <li>Selecione o pacote e explique o motivo</li>
+    </ol>
+    <p>Você tem até 45 dias para solicitar reembolso na App Store.</p>
+
+    <h3>Restaurar compras</h3>
+    <p>Se você comprou um pacote e desinstalou o app, pode restaurar em Configurações → [Seu nome] → iTunes e App Stores → Restaurar compras.</p>
+
+    <p>Restauração funciona apenas com a mesma conta Apple ID que fez a compra.</p>
+
+    <h2>6. Limitação de responsabilidade</h2>
+
+    <h3>Sem garantias</h3>
+    <p><strong>GameNow é fornecido "como está".</strong> Sem garantias de:</p>
+    <ul>
+      <li>Funcionamento ininterrupto (pode ter bugs)</li>
+      <li>Disponibilidade futura (o app pode ser descontinuado)</li>
+      <li>Recuperação de dados (se você apagar, não posso restaurar)</li>
+      <li>Resultado pedagógico (aprender depende de você)</li>
+    </ul>
+
+    <h3>Sem responsabilidade por danos</h3>
+    <p>Em nenhuma circunstância, Pablo Custodio Carneiro ou qualquer entidade associada é responsável por:</p>
+    <ul>
+      <li>Dados perdidos ou corrompidos</li>
+      <li>Interrupções do serviço</li>
+      <li>Falha em exames ou avaliações (você aprendeu pouco)</li>
+      <li>Qualquer perda indireta, incidental ou consequente</li>
+    </ul>
+
+    <h2>7. Conteúdo do usuário</h2>
+
+    <h3>Nenhuma obrigação de monitorar</h3>
+    <p>GameNow não permite upload de conteúdo pelo usuário (sem chat, comentários, fórums). Não há responsabilidade sobre conteúdo criado por terceiros.</p>
+
+    <h3>Dados e feedback</h3>
+    <p>Se você envia email com sugestões ou reportes de bug, isso se torna propriedade de GameNow e pode ser usado para melhorar o app.</p>
+
+    <h2>8. Rescisão</h2>
+
+    <p>Você pode parar de usar GameNow a qualquer momento desinstalando o app.</p>
+
+    <p>Pablo Custodio Carneiro pode rescindi sua licença (remover o app da App Store) se você violar estes termos. Mas isso é improvável — use honestamente e tudo bem.</p>
+
+    <h2>9. Modificações</h2>
+
+    <p>GameNow pode ser atualizado, modificado ou descontinuado sem aviso prévio. Atualizações podem incluir:</p>
+    <ul>
+      <li>Novas features</li>
+      <li>Mudanças no funcionamento</li>
+      <li>Mudanças na monetização</li>
+    </ul>
+
+    <p>Se você não gosta de uma atualização, você não é obrigado a atualizá-la (fica com a versão anterior).</p>
+
+    <h2>10. Lei aplicável</h2>
+
+    <p>Estes termos são regidos pelas leis do Brasil (Lei Geral de Proteção de Dados, Código Brasileiro de Defesa do Consumidor) e qualquer disputa será resolvida em fórum brasileiro.</p>
+
+    <p>Para usuários fora do Brasil: leis locais também podem se aplicar (GDPR na Europa, CCPA na Califórnia, etc.).</p>
+
+    <h2>11. Resolução de conflitos</h2>
+
+    <p><strong>Abordagem amigável:</strong> Se há problema, envie email para <a href="mailto:apple@pablocustodio.com.br">apple@pablocustodio.com.br</a> e vamos resolver juntos.</p>
+
+    <p><strong>Arbitragem:</strong> Se não conseguir resolver por email, qualquer disputa será resolvida por arbitragem (não em tribunal).</p>
+
+    <h2>12. Contato</h2>
+
+    <p><strong>Email:</strong> <a href="mailto:apple@pablocustodio.com.br">apple@pablocustodio.com.br</a></p>
+
+    <p>Para dúvidas sobre estes termos, entre em contato.</p>
+
+    <h2>13. Resumo</h2>
+
+    <ul>
+      <li>✅ Você pode usar o app para aprender inglês</li>
+      <li>❌ Você não pode copiar ou vender o app</li>
+      <li>⚠️ Sem garantias — o app é fornecido "como está"</li>
+      <li>💰 Compras na App Store são da Apple, não de GameNow</li>
+      <li>📧 Problemas? Envie email</li>
+    </ul>
+  </div>
+
+  <footer>
+    <p>&copy; 2026 Pablo Custodio Carneiro. Todos os direitos reservados.</p>
+    <p style="margin-top: 15px; font-size: 14px;">
+      <a href="/index.html">Início</a> •
+      <a href="/support.html">Suporte</a> •
+      <a href="/privacy-policy.html">Privacidade</a>
+    </p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a new `gamenow/` subfolder containing the provided GameNow static pages:

- `gamenow/index.html`
- `gamenow/privacy-policy.html`
- `gamenow/support.html`
- `gamenow/terms-of-service.html`

## Validation

Compared `codex/add-gamenow-pages` against `main` and confirmed the branch adds only those four files.