### PR TITLE
[codex] Fix GameNow index links

### DIFF
--- a/gamenow/index.html
+++ b/gamenow/index.html
@@ -128,8 +128,8 @@
     <div class="cta">
       <h3>Dúvidas?</h3>
       <p>
-        <a href="/support.html" class="btn">Suporte</a>
-        <a href="/privacy-policy.html" class="btn">Privacidade</a>
+        <a href="/gamenow/support.html" class="btn">Suporte</a>
+        <a href="/gamenow/privacy-policy.html" class="btn">Privacidade</a>
       </p>
     </div>
   </div>
@@ -137,9 +137,9 @@
   <footer>
     <p>&copy; 2026 Pablo Custodio Carneiro. Todos os direitos reservados.</p>
     <p style="margin-top: 15px; font-size: 14px;">
-      <a href="/privacy-policy.html">Política de Privacidade</a> •
-      <a href="/terms-of-service.html">Termos de Serviço</a> •
-      <a href="/support.html">Suporte</a>
+      <a href="/gamenow/privacy-policy.html">Política de Privacidade</a> •
+      <a href="/gamenow/terms-of-service.html">Termos de Serviço</a> •
+      <a href="/gamenow/support.html">Suporte</a>
     </p>
   </footer>
 </body>


### PR DESCRIPTION
## Summary

Updates the internal links in `gamenow/index.html` so they point to the GameNow subfolder paths:

- `/gamenow/privacy-policy.html`
- `/gamenow/terms-of-service.html`
- `/gamenow/support.html`

The CTA links for support and privacy were updated as well.

## Validation

Compared `codex/fix-gamenow-index-links` against `main`; only `gamenow/index.html` changed, with 5 link updates.