### PR TITLE
[codex] Fix GameNow page footer links

### DIFF
--- a/gamenow/privacy-policy.html
+++ b/gamenow/privacy-policy.html
@@ -249,9 +249,9 @@
   <footer>
     <p>&copy; 2026 Pablo Custodio Carneiro. Todos os direitos reservados.</p>
     <p style="margin-top: 15px; font-size: 14px;">
-      <a href="/index.html">Início</a> •
-      <a href="/support.html">Suporte</a> •
-      <a href="/terms-of-service.html">Termos</a>
+      <a href="/gamenow/index.html">Início</a> •
+      <a href="/gamenow/support.html">Suporte</a> •
+      <a href="/gamenow/terms-of-service.html">Termos</a>
     </p>
   </footer>
 </body>

--- a/gamenow/support.html
+++ b/gamenow/support.html
@@ -174,9 +174,9 @@
   <footer>
     <p>&copy; 2026 Pablo Custodio Carneiro. Todos os direitos reservados.</p>
     <p style="margin-top: 15px; font-size: 14px;">
-      <a href="/index.html">Início</a> •
-      <a href="/privacy-policy.html">Privacidade</a> •
-      <a href="/terms-of-service.html">Termos</a>
+      <a href="/gamenow/index.html">Início</a> •
+      <a href="/gamenow/privacy-policy.html">Privacidade</a> •
+      <a href="/gamenow/terms-of-service.html">Termos</a>
     </p>
   </footer>
 </body>

--- a/gamenow/terms-of-service.html
+++ b/gamenow/terms-of-service.html
@@ -218,9 +218,9 @@
   <footer>
     <p>&copy; 2026 Pablo Custodio Carneiro. Todos os direitos reservados.</p>
     <p style="margin-top: 15px; font-size: 14px;">
-      <a href="/index.html">Início</a> •
-      <a href="/support.html">Suporte</a> •
-      <a href="/privacy-policy.html">Privacidade</a>
+      <a href="/gamenow/index.html">Início</a> •
+      <a href="/gamenow/support.html">Suporte</a> •
+      <a href="/gamenow/privacy-policy.html">Privacidade</a>
     </p>
   </footer>
 </body>


### PR DESCRIPTION
## Summary

Updates the footer links in the remaining GameNow pages so internal navigation stays under `/gamenow/`:

- `gamenow/privacy-policy.html`
- `gamenow/support.html`
- `gamenow/terms-of-service.html`

## Validation

Compared the branch against `main`; the remaining diff changes only those three pages, with three link updates in each footer.